### PR TITLE
Untangle the Jira import

### DIFF
--- a/estimage/history/aggregation.py
+++ b/estimage/history/aggregation.py
@@ -148,6 +148,7 @@ class Aggregation:
     def __init__(self, statuses=None):
         self.repres = []
         self.statuses = statuses
+        self._card_names = set()
         if not self.statuses:
             self.statuses = status.Statuses()
 
@@ -164,6 +165,7 @@ class Aggregation:
             start: datetime.datetime, end: datetime.datetime,
             statuses: status.Statuses=None) -> "Aggregation":
         ret = cls(statuses)
+        known_cards = set()
         for s in sources:
             for r in convert_card_to_representations_of_leaves(s, start, end, ret.statuses):
                 ret.add_repre(r)
@@ -211,10 +213,15 @@ class Aggregation:
                 raise ValueError(msg) from exc
 
     def add_repre(self, repre):
+        card_name = repre.task_name
         if (self.end and self.end != repre.end) or (self.start and self.start != repre.start):
-            msg = "Incompatible timespan of the representation"
+            msg = f"Incompatible timespan of progress of '{card_name}' {repre.start}--{repre.end}"
+            raise ValueError(msg)
+        if card_name in self._card_names:
+            msg = f"Attempted repeated insertion of progress of '{card_name}'"
             raise ValueError(msg)
         self.repres.append(repre)
+        self._card_names.add(card_name)
 
     def statuses_on(self, when):
         states = set()

--- a/estimage/persistence/__init__.py
+++ b/estimage/persistence/__init__.py
@@ -5,15 +5,23 @@ LOADERS = collections.defaultdict(dict)
 SAVERS = collections.defaultdict(dict)
 
 
+def register_loader_of(loaded, backend, loader):
+    LOADERS[loaded][backend] = loader
+
+
+def register_saver_of(saved, backend, saver):
+    SAVERS[saved][backend] = saver
+
+
 def loader_of(loaded, backend):
     def decorator(loader):
-        LOADERS[loaded][backend] = loader
+        register_loader_of(loaded, backend, loader)
         return loader
     return decorator
 
 
 def saver_of(saved, backend):
     def decorator(saver):
-        SAVERS[saved][backend] = saver
+        register_saver_of(saved, backend, saver)
         return saver
     return decorator

--- a/estimage/plugins/jira/__init__.py
+++ b/estimage/plugins/jira/__init__.py
@@ -111,11 +111,6 @@ def get_name_from_person_field(field_contents):
     return field_contents.emailAddress.split("@", 1)[0]
 
 
-def inherit_attributes(parent, child):
-    parent.add_element(child)
-    child.tier = parent.tier
-
-
 def save_exported_jira_tasks(all_cards_by_id, id_selection, card_io_class):
     to_save = [all_cards_by_id[tid] for tid in id_selection]
     card_io_class.bulk_save_metadata(to_save)
@@ -331,12 +326,16 @@ class Importer:
         for root_name in root_names:
             self.resolve_inheritance_of_attributes(root_name)
 
+    def inherit_attributes(self, parent, child):
+        parent.add_element(child)
+        child.tier = parent.tier
+
     def resolve_inheritance_of_attributes(self, name):
         item = self._cards_by_id[name]
         child_names = self._parent_name_to_children_names.get(item.name, [])
         for child_name in child_names:
             child = self._cards_by_id[child_name]
-            inherit_attributes(item, child)
+            self.inherit_attributes(item, child)
             self.resolve_inheritance_of_attributes(child_name)
 
     def _get_contents_of_rendered_field(self, item, field_name):

--- a/estimage/plugins/jira/importer.py
+++ b/estimage/plugins/jira/importer.py
@@ -1,0 +1,96 @@
+import time
+
+from jira import JIRA, exceptions
+
+
+JIRA_STATUS_TO_STATE = {
+    "New": "todo",
+    "Done": "done",
+    "Closed": "irrelevant",
+    "In Progress": "in_progress",
+    "To Do": "todo",
+}
+
+
+def jira_retry(func, * args, ** kwargs):
+    return jira_retry_n(5, 5, func, * args, ** kwargs)
+
+
+def jira_retry_n(retries, longest_pause, func, * args, ** kwargs):
+    try:
+        result = func(* args, ** kwargs)
+    except exceptions.JIRAError:
+        if retries <= 0:
+            raise
+        time.sleep(longest_pause / retries)
+        print(f"Failed {func.__name__}, retrying {retries} more times")
+        result = jira_retry_n(retries - 1, longest_pause, func, * args, ** kwargs)
+    return result
+
+
+class JiraWithRetry(JIRA):
+    def search_issues(self, * args, ** kwargs):
+        return jira_retry(super().search_issues, * args, ** kwargs)
+
+    def issue(self, * args, ** kwargs):
+        return jira_retry(super().issue, * args, ** kwargs)
+
+
+class BareboneImporter:
+    def __init__(self, spec):
+        self._cards_by_id = dict()
+        self._all_issues_by_name = dict()
+        self._parent_name_to_children_names = dict()
+
+        self._retro_cards = set()
+        self._projective_cards = set()
+        self._all_events = []
+
+        try:
+            self.jira = JiraWithRetry(spec.server_url, token_auth=spec.token, validate=True)
+        except exceptions.JIRAError as exc:
+            msg = f"Error establishing a Jira session: {exc.text}"
+            raise RuntimeError(msg) from exc
+        self.item_class = spec.item_class
+
+    def report(self, msg):
+        print(msg)
+
+    def find_card(self, name: str):
+        card = self.jira.issue(name)
+        if not card:
+            msg = f"{card} not found"
+            raise ValueError(msg)
+        return card
+
+    @classmethod
+    def status_to_state(cls, item, jira_string=""):
+        if not jira_string:
+            jira_string = item.get_field("status").name
+        ret = cls._status_to_state(item, jira_string)
+        return ret
+
+    @classmethod
+    def _status_to_state(cls, item, jira_string):
+        if cls._item_is_closed_done(item, jira_string):
+            jira_string = "Done"
+        return JIRA_STATUS_TO_STATE.get(jira_string, "irrelevant")
+
+    @classmethod
+    def _get_contents_of_rendered_field(cls, item, field_name):
+        ret = cls._get_contents_of_field(item, field_name, "")
+        try:
+            ret = getattr(item.renderedFields, field_name)
+        except AttributeError:
+            pass
+        ret = ret.replace("\r", "")
+        return ret
+
+    @classmethod
+    def _get_contents_of_field(cls, item, field_name, default_value=None):
+        ret = default_value
+        try:
+            ret = item.get_field(field_name) or default_value
+        except AttributeError:
+            pass
+        return ret

--- a/estimage/plugins/jira/routes.py
+++ b/estimage/plugins/jira/routes.py
@@ -1,6 +1,8 @@
 import flask
 import flask_login
 
+from jira import exceptions
+
 from ...webapp import web_utils
 from .. import jira
 from . import forms
@@ -13,7 +15,7 @@ def try_callback_and_produce_error_msg(argument, callback):
     try:
         stats = callback(argument)
         flask.flash(jira.stats_to_summary(stats))
-    except jira.exceptions.JIRAError as exc:
+    except exceptions.JIRAError as exc:
         if 500 <= exc.status_code < 600:
             error_msg = f"Error {exc.status_code} when interacting with Jira, accessing URL {exc.url}"
         else:

--- a/estimage/plugins/jira/tests/test_jira.py
+++ b/estimage/plugins/jira/tests/test_jira.py
@@ -3,12 +3,6 @@ import estimage.plugins.jira as tm
 from estimage import data
 
 
-def test_resolve_inheritance_trivial():
-    a = data.BaseCard("")
-    tm.resolve_inheritance_of_attributes("a", dict(a=a), dict())
-
-
-
 def test_format_stats():
     data = tm.Collected(Retrospective=0, Projective=0, Events=0)
     assert tm.stats_to_summary(data) == "Collected nothing."

--- a/estimage/plugins/redhat_compliance/__init__.py
+++ b/estimage/plugins/redhat_compliance/__init__.py
@@ -8,14 +8,17 @@ from ... import simpledata, data, persistence
 from ...entities import status
 from ...webapp import web_utils
 from ...visualize.burndown import StatusStyle
-from .. import jira
+from .. import jira, redhat_jira
 from ..jira.forms import AuthoritativeForm, ProblemForm
 
+
+BaseCardWithStatus = redhat_jira.BaseCardWithStatus
+CardSynchronizer = redhat_jira.CardSynchronizer
 
 EXPORTS = dict(
     AuthoritativeForm="AuthoritativeForm",
     ProblemForm="ProblemForm",
-    BaseCard="BaseCard",
+    BaseCard="BaseCardWithStatus",
     MPLPointPlot="MPLPointPlot",
     Statuses="Statuses",
     CardSynchronizer="CardSynchronizer",
@@ -33,33 +36,7 @@ TEMPLATE_OVERRIDES = {
 }
 
 
-RHEL_STATUS_TO_STATE = {
-    "New": "todo",
-    "Planning": "todo",
-    "Verified": "done",
-    "Closed": "done",
-    "Done": "done", # not really a state, but used
-    "In Progress": "rhel-in_progress",
-    "Integration": "rhel-integration",
-    "Release Pending": "done",
-    "To Do": "todo",
-}
-
-
-RHELPLAN_STATUS_TO_STATE = {
-    "New": "todo",
-    "Verified": "done",
-    "Closed": "done",
-    "Abandoned": "irrelevant",
-    "ASSIGNED": "rhel-in_progress",
-    "ON_DEV": "rhel-in_progress",
-    "POST": "rhel-in_progress",
-    "MODIFIED": "rhel-integration",
-    "ON_QA": "rhel-integration",
-}
-
-
-JIRA_STATUS_TO_STATE = {
+OPENSCAP_STATUS_TO_STATE = {
     "Backlog": "todo",
     "Refinement": "todo",
     "New": "todo",
@@ -72,34 +49,29 @@ JIRA_STATUS_TO_STATE = {
     "To Do": "todo",
 }
 
-class CardSynchronizer(jira.CardSynchronizer):
-    @classmethod
-    def from_form(cls, form):
-        kwargs = dict()
-        kwargs["server_url"] = "https://issues.redhat.com"
-        kwargs["token"] = form.token.data
-        kwargs["importer_cls"] = Importer
-        return cls(** kwargs)
 
-
-class InputSpec(jira.InputSpec):
-    @classmethod
-    def from_form_and_app(cls, input_form, app) -> "InputSpec":
-        ret = cls()
-        ret.server_url = "https://issues.redhat.com"
-        ret.token = input_form.token.data
+class InputSpec(redhat_jira.InputSpec):
+    def _get_epochs(self, input_form):
         epoch = input_form.quarter.data
         planning_epoch = epoch
         if input_form.project_next.data:
             planning_epoch = next_epoch_of(planning_epoch)
-        ret.cutoff_date = epoch_start_to_datetime(epoch)
+
+        return epoch, planning_epoch
+
+    def set_cutoff_date(self, input_form):
+        epoch, planning_epoch = self._get_epochs(input_form)
+
+        self.cutoff_date = epoch_start_to_datetime(epoch)
+
+    def set_queries(self, input_form):
+        epoch, planning_epoch = self._get_epochs(input_form)
+
         query_lead = f"project = {PROJECT_NAME} AND type = Epic AND"
         retro_narrowing = f"sprint = {epoch} AND Commitment in (Committed, Planned)"
         proj_narrowing = f"sprint = {planning_epoch}"
-        ret.retrospective_query = " ".join((query_lead, retro_narrowing))
-        ret.projective_query = " ".join((query_lead, proj_narrowing))
-        ret.item_class = app.get_final_class("BaseCard")
-        return ret
+        self.retrospective_query = " ".join((query_lead, retro_narrowing))
+        self.projective_query = " ".join((query_lead, proj_narrowing))
 
 
 def epoch_start_to_datetime(epoch: str):
@@ -134,78 +106,14 @@ def days_to_next_epoch(date: datetime.datetime) -> int:
     return (end - date).days
 
 
-def extract_status_updates(all_events):
-    last_updates = dict()
-    for e in all_events:
-        if not e.quantity == "status_summary":
-            continue
-        put_status_update_time_into_results(last_updates, e)
-    return last_updates
-
-
-def put_status_update_time_into_results(results, update_event):
-    task_name = update_event.task_name
-    if task_name in results:
-        results[task_name] = max(results[task_name], update_event.time)
-    else:
-        results[task_name] = update_event.time
-
-
-def apply_status_updates(issues_by_name, all_events):
-    last_updates_by_id = extract_status_updates(all_events)
-    for issue_name, date in last_updates_by_id.items():
-        issues_by_name[issue_name].status_summary_time = date
-
-
-def apply_some_events_into_issues(issues_by_name, all_events):
-    apply_status_updates(issues_by_name, all_events)
-
-
-class Importer(jira.Importer):
-    STORY_POINTS = "customfield_12310243"
-    EPIC_LINK = "customfield_12311140"
-    CONTRIBUTORS = "customfield_12315950"
-    COMMITMENT = "customfield_12317404"
-    STATUS_SUMMARY_OLD = "customfield_12317299"
-    STATUS_SUMMARY_NEW = "customfield_12320841"
-    WORK_START = "customfield_12313941"
-    WORK_END = "customfield_12313942"
-
-    def _get_points_of(self, item):
-        ret = self._get_contents_of_field(item, self.STORY_POINTS, 0)
-        return ret
-
-    def _set_points_of(self, item, points):
-        item.update({self.STORY_POINTS: round(points, 2)})
-
-    def _get_status_summary(self, item):
-        ret = self._get_contents_of_rendered_field(item, self.STATUS_SUMMARY_OLD)
-        if ret:
-            return ret
-        ret = self._get_contents_of_rendered_field(item, self.STATUS_SUMMARY_NEW)
-        return ret
+class Importer(redhat_jira.ImporterWithStatus):
 
     def merge_jira_item_without_children(self, item):
 
         result = super().merge_jira_item_without_children(item)
 
-        result.point_cost = self._get_points_of(item)
-        result.status_summary = self._get_status_summary(item)
-        result.loading_plugin = "jira-rhcompliance"
-        self._record_collaborators(result, item)
-        self._record_work_span(result, item)
-
         self._record_commitment_as_tier_and_tags(result, item)
-
         return result
-
-    def _record_collaborators(self, result, item):
-        result.collaborators = []
-        try:
-            result.collaborators += [
-                jira.get_name_from_person_field(c) for c in item.get_field(self.CONTRIBUTORS) or []]
-        except AttributeError:
-            pass
 
     def _record_commitment_as_tier_and_tags(self, result, item):
         result.tier = 0
@@ -217,60 +125,17 @@ class Importer(jira.Importer):
         except AttributeError:
             pass
 
-    def _record_work_span(self, result, item):
-        work_span = [None, None]
-        if work_end := item.get_field(self.WORK_END):
-            work_span[-1] = jira.jira_date_to_datetime(work_end)
-
-        if work_start := item.get_field(self.WORK_START):
-            work_span[0] = jira.jira_date_to_datetime(work_start)
-
-        if work_span[0] or work_span[-1]:
-            result.work_span = tuple(work_span)
-
-    def get_points_of(self, our_task):
-        jira_task = self.find_card(our_task.name)
-        remote_points = self._get_points_of(jira_task)
-        return remote_points
-
-    def update_points_of(self, our_task, points):
-        jira_task = self.find_card(our_task.name)
-        self._set_points_of(jira_task, points)
-        our_task.point_cost = points
-        return our_task
-
-    def save(self, retro_card_io_class, proj_card_io_class, event_manager_class):
-        apply_some_events_into_issues(self._cards_by_id, self._all_events)
-        return super().save(retro_card_io_class, proj_card_io_class, event_manager_class)
-
     @classmethod
     def _status_to_state(cls, item, jira_string):
+        if cls._item_is_closed_done(item, jira_string):
+            return "done"
+
         item_name = item.key
 
         if item_name.startswith("OPENSCAP"):
-            return super()._status_to_state(item, jira_string)
-        elif item_name.startswith("RHELPLAN"):
-            return RHELPLAN_STATUS_TO_STATE.get(jira_string, "irrelevant")
-        elif item_name.startswith("RHEL"):
-            return RHEL_STATUS_TO_STATE.get(jira_string, "irrelevant")
+            return OPENSCAP_STATUS_TO_STATE.get(jira_string, "irrelevant")
         else:
-            return JIRA_STATUS_TO_STATE.get(jira_string, "irrelevant")
-
-
-def _get_simple_spec(token, card_cls):
-    Spec = collections.namedtuple("Spec", ["server_url", "token", "item_class"])
-    spec = Spec(
-        server_url="https://issues.redhat.com",
-        token=token,
-        item_class=card_cls)
-    return spec
-
-
-def refresh_cards(names, io_cls, card_cls, token):
-    spec = _get_simple_spec(token, card_cls)
-    real_cards = [data.BaseCard.load_metadata(name, io_cls) for name in names]
-    importer = Importer(spec)
-    importer.refresh_cards(real_cards, io_cls)
+            return super()._status_to_state(item, jira_string)
 
 
 def do_stuff(spec):
@@ -299,42 +164,6 @@ class MPLPointPlot:
         ret["rhel-in_progress"] = StatusStyle(color=(0.1, 0.2, 0.5, 0.4), label="BZ In Progress", weight=60)
         ret["rhel-integration"] = StatusStyle(color=(0.2, 0.4, 0.7, 0.6), label="BZ Integration", weight=61)
         return ret
-
-
-class BaseCard:
-    status_summary: str
-    status_summary_time: datetime.datetime
-
-    def __init__(self, * args, **kwargs):
-        super().__init__(* args, ** kwargs)
-
-        self.status_summary = ""
-        self.status_summary_time = None
-
-    def pass_data_to_saver(self, saver):
-        super().pass_data_to_saver(saver)
-        saver.save_status_update(self)
-
-    def load_data_by_loader(self, loader):
-        super().load_data_by_loader(loader)
-        loader.load_status_update(self)
-
-
-@persistence.loader_of(BaseCard, "ini")
-class IniCardStateLoader:
-    def load_status_update(self, t):
-        t.status_summary = self._get_our(t, "status_summary")
-        time_str = self._get_our(t, "status_summary_time")
-        if time_str:
-            t.status_summary_time = datetime.datetime.fromisoformat(time_str)
-
-
-@persistence.saver_of(BaseCard, "ini")
-class IniCardStateSaver:
-    def save_status_update(self, t):
-        self._store_our(t, "status_summary")
-        if t.status_summary_time:
-            self._store_our(t, "status_summary_time", t.status_summary_time.isoformat())
 
 
 class Workloads:

--- a/estimage/plugins/redhat_compliance/__init__.py
+++ b/estimage/plugins/redhat_compliance/__init__.py
@@ -172,7 +172,8 @@ class Importer(jira.Importer):
     WORK_END = "customfield_12313942"
 
     def _get_points_of(self, item):
-        return float(item.get_field(self.STORY_POINTS) or 0)
+        ret = self._get_contents_of_field(item, self.STORY_POINTS, 0)
+        return ret
 
     def _set_points_of(self, item, points):
         item.update({self.STORY_POINTS: round(points, 2)})
@@ -192,8 +193,9 @@ class Importer(jira.Importer):
         result.status_summary = self._get_status_summary(item)
         result.loading_plugin = "jira-rhcompliance"
         self._record_collaborators(result, item)
-        self._record_commitment_as_tier_and_tags(result, item)
         self._record_work_span(result, item)
+
+        self._record_commitment_as_tier_and_tags(result, item)
 
         return result
 
@@ -201,7 +203,7 @@ class Importer(jira.Importer):
         result.collaborators = []
         try:
             result.collaborators += [
-                jira.name_from_field(c) for c in item.get_field(self.CONTRIBUTORS) or []]
+                jira.get_name_from_person_field(c) for c in item.get_field(self.CONTRIBUTORS) or []]
         except AttributeError:
             pass
 

--- a/estimage/plugins/redhat_compliance/tests/test_rhcompliance_target.py
+++ b/estimage/plugins/redhat_compliance/tests/test_rhcompliance_target.py
@@ -1,7 +1,6 @@
 import pytest
 
 from estimage import plugins, PluginResolver, persistence
-from estimage.data import BaseCard
 import estimage.plugins.redhat_compliance as tm
 
 from tests.test_card import base_card_load_save, fill_card_instance_with_stuff, assert_cards_are_equal
@@ -10,7 +9,7 @@ from tests.test_inidata import temp_filename, cardio_inifile_cls
 
 @pytest.fixture(params=("ini",))
 def card_io(request, cardio_inifile_cls):
-    cls = tm.BaseCard
+    cls = tm.BaseCardWithStatus
     choices = dict(
         ini=cardio_inifile_cls,
     )
@@ -26,7 +25,6 @@ def plugin_fill(t):
     fill_card_instance_with_stuff(t)
 
     t.status_summary = "Lorem Ipsum and So On"
-    # t.status_summary_time = datetime.datetime(1918, 8, 3)
 
 
 def plugin_test(lhs, rhs):

--- a/estimage/plugins/redhat_jira/__init__.py
+++ b/estimage/plugins/redhat_jira/__init__.py
@@ -1,0 +1,217 @@
+import datetime
+
+from ... import persistence
+from .. import jira
+
+
+RHEL_STATUS_TO_STATE = {
+    "New": "todo",
+    "Planning": "todo",
+    "Verified": "done",
+    "Done": "done", # not really a state, but used
+    "In Progress": "rhel-in_progress",
+    "Integration": "rhel-integration",
+    "Release Pending": "done",
+    "To Do": "todo",
+}
+
+
+RHELPLAN_STATUS_TO_STATE = {
+    "New": "todo",
+    "Verified": "done",
+    "Abandoned": "irrelevant",
+    "ASSIGNED": "rhel-in_progress",
+    "ON_DEV": "rhel-in_progress",
+    "POST": "rhel-in_progress",
+    "MODIFIED": "rhel-integration",
+    "ON_QA": "rhel-integration",
+}
+
+
+class EventExtractor(jira.EventExtractor):
+    STORY_POINTS = "customfield_12310243"
+
+    def _field_to_event(self, date, field_name, former_value, new_value):
+        evt = super()._field_to_event(date, field_name, former_value, new_value)
+        if field_name == self.STORY_POINTS:
+            evt = evts.Event(self.task.key, "points", date)
+            evt.value_before = float(former_value or 0)
+            evt.value_after = float(new_value or 0)
+            evt.msg = f"Points changed from {former_value} to {new_value}"
+        elif field_name in ("Latest Status Summary", "Status Summary"):
+            evt = evts.Event(self.task.key, "status_summary", date)
+            evt.value_before = former_value
+            evt.value_after = new_value
+            evt.msg = f"Event summary changed to {new_value}"
+        return evt
+
+
+class InputSpec(jira.InputSpec):
+    @classmethod
+    def from_form_and_app(cls, input_form, app) -> "InputSpec":
+        ret = cls()
+        ret.token = input_form.token.data
+        ret.server_url = "https://issues.redhat.com"
+        ret.item_class = app.get_final_class("BaseCard")
+        ret.set_cutoff_date(input_form)
+        ret.set_queries(input_form)
+        return ret
+
+
+class Importer(jira.Importer):
+    STORY_POINTS = "customfield_12310243"
+    EPIC_LINK = "customfield_12311140"
+    CONTRIBUTORS = "customfield_12315950"
+    WORK_START = "customfield_12313941"
+    WORK_END = "customfield_12313942"
+
+    def _get_points_of(self, item):
+        ret = self._get_contents_of_field(item, self.STORY_POINTS, 0)
+        return ret
+
+    def _set_points_of(self, item, points):
+        item.update({self.STORY_POINTS: round(points, 2)})
+
+    @classmethod
+    def _status_to_state(cls, item, jira_string):
+        if cls._item_is_closed_done(item, jira_string):
+            return "done"
+
+        item_name = item.key
+
+        if item_name.startswith("RHELPLAN"):
+            return RHELPLAN_STATUS_TO_STATE.get(jira_string, "irrelevant")
+        elif item_name.startswith("RHEL"):
+            return RHEL_STATUS_TO_STATE.get(jira_string, "irrelevant")
+        else:
+            return super()._status_to_state(item, jira_string)
+
+    def merge_jira_item_without_children(self, item):
+
+        result = super().merge_jira_item_without_children(item)
+
+        result.point_cost = self._get_points_of(item)
+        result.status_summary = self._get_status_summary(item)
+        result.loading_plugin = "jira-rhcompliance"
+        self._record_collaborators(result, item)
+        self._record_work_span(result, item)
+        return result
+
+    def _record_collaborators(self, result, item):
+        result.collaborators = []
+        try:
+            result.collaborators += [
+                jira.get_name_from_person_field(c) for c in item.get_field(self.CONTRIBUTORS) or []]
+        except AttributeError:
+            pass
+
+    def _record_work_span(self, result, item):
+        work_span = [None, None]
+        if work_end := item.get_field(self.WORK_END):
+            work_span[-1] = jira.jira_date_to_datetime(work_end)
+
+        if work_start := item.get_field(self.WORK_START):
+            work_span[0] = jira.jira_date_to_datetime(work_start)
+
+        if work_span[0] or work_span[-1]:
+            result.work_span = tuple(work_span)
+
+    def get_points_of(self, our_task):
+        jira_task = self.find_card(our_task.name)
+        remote_points = self._get_points_of(jira_task)
+        return remote_points
+
+    def update_points_of(self, our_task, points):
+        jira_task = self.find_card(our_task.name)
+        self._set_points_of(jira_task, points)
+        our_task.point_cost = points
+        return our_task
+
+
+def extract_status_updates(all_events):
+    last_updates = dict()
+    for e in all_events:
+        if not e.quantity == "status_summary":
+            continue
+        put_status_update_time_into_results(last_updates, e)
+    return last_updates
+
+
+def put_status_update_time_into_results(results, update_event):
+    task_name = update_event.task_name
+    if task_name in results:
+        results[task_name] = max(results[task_name], update_event.time)
+    else:
+        results[task_name] = update_event.time
+
+
+def apply_status_updates(issues_by_name, all_events):
+    last_updates_by_id = extract_status_updates(all_events)
+    for issue_name, date in last_updates_by_id.items():
+        issues_by_name[issue_name].status_summary_time = date
+
+
+def apply_some_events_into_issues(issues_by_name, all_events):
+    apply_status_updates(issues_by_name, all_events)
+
+
+class ImporterWithStatus(Importer):
+    STATUS_SUMMARY_OLD = "customfield_12317299"
+    STATUS_SUMMARY_NEW = "customfield_12320841"
+
+    def save(self, retro_card_io_class, proj_card_io_class, event_manager_class):
+        apply_some_events_into_issues(self._cards_by_id, self._all_events)
+        return super().save(retro_card_io_class, proj_card_io_class, event_manager_class)
+
+    def _get_status_summary(self, item):
+        ret = self._get_contents_of_rendered_field(item, self.STATUS_SUMMARY_OLD)
+        if ret:
+            return ret
+        ret = self._get_contents_of_rendered_field(item, self.STATUS_SUMMARY_NEW)
+        return ret
+
+
+class BaseCardWithStatus:
+    status_summary: str
+    status_summary_time: datetime.datetime
+
+    def __init__(self, * args, **kwargs):
+        super().__init__(* args, ** kwargs)
+
+        self.status_summary = ""
+        self.status_summary_time = None
+
+    def pass_data_to_saver(self, saver):
+        super().pass_data_to_saver(saver)
+        saver.save_status_update(self)
+
+    def load_data_by_loader(self, loader):
+        super().load_data_by_loader(loader)
+        loader.load_status_update(self)
+
+
+@persistence.loader_of(BaseCardWithStatus, "ini")
+class IniCardStateLoader:
+    def load_status_update(self, t):
+        t.status_summary = self._get_our(t, "status_summary")
+        time_str = self._get_our(t, "status_summary_time")
+        if time_str:
+            t.status_summary_time = datetime.datetime.fromisoformat(time_str)
+
+
+@persistence.saver_of(BaseCardWithStatus, "ini")
+class IniCardStateSaver:
+    def save_status_update(self, t):
+        self._store_our(t, "status_summary")
+        if t.status_summary_time:
+            self._store_our(t, "status_summary_time", t.status_summary_time.isoformat())
+
+
+class CardSynchronizer(jira.CardSynchronizer):
+    @classmethod
+    def from_form(cls, form):
+        kwargs = dict()
+        kwargs["server_url"] = "https://issues.redhat.com"
+        kwargs["token"] = form.token.data
+        kwargs["importer_cls"] = Importer
+        return cls(** kwargs)

--- a/tests/test_history_progress.py
+++ b/tests/test_history_progress.py
@@ -44,14 +44,6 @@ def test_irrelevant_statuses():
 
 
 @pytest.fixture
-def simple_card():
-    ret = card.BaseCard("task")
-    ret.point_cost = 8
-    ret.status = "todo"
-    return ret
-
-
-@pytest.fixture
 def repre():
     start = PERIOD_START
     end = LONG_PERIOD_END


### PR DESCRIPTION
Make the Jira import code more logically structured, and by extension easier to be reused in various plugins.